### PR TITLE
Update README.md with instructions to avoid Rake error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ And then:
 
 ### Setup and usage
 
-Add this line to `Capfile`
+Add this line to `Capfile`, after `require 'capistrano/rails/assets'`
 
     require 'capistrano/faster_assets'
 


### PR DESCRIPTION
If requiring `faster_assets` before `rails/assets`, you'll receive this error:

```
$ cap -T --trace
cap aborted!
Don't know how to build task 'deploy:assets:precompile'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/task_manager.rb:62:in `[]'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/task.rb:353:in `[]'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-faster-assets-1.0.0/lib/capistrano/tasks/faster_assets.rake:8:in `<top (required)>'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-faster-assets-1.0.0/lib/capistrano/faster_assets.rb:1:in `load'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-faster-assets-1.0.0/lib/capistrano/faster_assets.rb:1:in `<top (required)>'
/Users/user/Projects/my-project/Capfile:19:in `require'
/Users/user/Projects/my-project/Capfile:19:in `<top (required)>'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_module.rb:28:in `load'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/rake_module.rb:28:in `load_rakefile'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/application.rb:687:in `raw_load_rakefile'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/application.rb:94:in `block in load_rakefile'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/application.rb:93:in `load_rakefile'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/application.rb:77:in `block in run'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rake-10.3.2/lib/rake/application.rb:75:in `run'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-3.2.1/lib/capistrano/application.rb:15:in `run'
/Users/user/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-3.2.1/bin/cap:3:in `<top (required)>'
/Users/user/.rbenv/versions/1.9.3-p448/bin/cap:23:in `load'
/Users/user/.rbenv/versions/1.9.3-p448/bin/cap:23:in `<main>'
```
