### PR TITLE
Make diff quieter and faster

### DIFF
--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -30,7 +30,7 @@ namespace :deploy do
 
               fetch(:assets_dependencies).each do |dep|
                 # execute raises if there is a diff
-                execute(:diff, '-Naur', release_path.join(dep), latest_release_path.join(dep)) rescue raise(PrecompileRequired)
+                execute(:diff, '-Nqr', release_path.join(dep), latest_release_path.join(dep)) rescue raise(PrecompileRequired)
               end
 
               info("Skipping asset precompile, no asset diff found")


### PR DESCRIPTION
Faster and quieter diffs:
- Uses binary diffs instead of ASCII diffs for faster and more reliable comparisons
- Will only check if files differ or not, thus it can stop at the first mismatch, and doesn't have to calculate the delta
- Doesn't output the delta, which can be very noisy especially with binary files treated as ASCII
