### PR TITLE
add T option

### DIFF
--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -42,7 +42,7 @@ namespace :deploy do
               info("Skipping asset precompile, no asset diff found")
 
               # copy over all of the assets from the last release
-              execute(:cp, '-r', latest_release_path.join('public', fetch(:assets_prefix)), release_path.join('public', fetch(:assets_prefix)))
+              execute(:cp, '-rT', latest_release_path.join('public', fetch(:assets_prefix)), release_path.join('public', fetch(:assets_prefix)))
             rescue PrecompileRequired
               execute(:rake, "assets:precompile")
             end


### PR DESCRIPTION
## Add T option to cp

In the target directory existing case, cp command doesn't work as expected.
```
$ mkdir -p source/assets
$ mkdir -p target/assets
$ touch source/assets/sample.txt
$ cp -r source/assets target/assets
$ tree target
target
`-- assets
    `-- assets
        `-- sample.txt

2 directories, 1 file
```

then, add T option, it works.
```
$ rm -fr target/assets/assets 
$ cp -Tr source/assets target/assets
$ tree target
target
`-- assets
    `-- sample.txt

1 directory, 1 file
```

It also works when target directory is not exists.
```
$ mkdir -p source/assets
$ mkdir target
$ touch source/assets/sample.txt
$ cp -Tr source/assets target/assets
$ tree target 
target
`-- assets
    `-- sample.txt

1 directory, 1 file
```