### PR TITLE
Merge #20 and add Assets compile environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ And then:
 Add this line to `Capfile`, after `require 'capistrano/rails/assets'`
 
     require 'capistrano/faster_assets'
+
+If U want to add some environment variable when compile assets, add `assets_env` in your stage file.
+
+```ruby
+set :assets_env, { doit: false }
+```
     
 ### Warning
 

--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -17,7 +17,7 @@ namespace :deploy do
         within release_path do
           with rails_env: fetch(:rails_env) do
             begin
-	      # find the most recent release
+              # find the most recent release
               latest_release = capture(:ls, '-xr', releases_path).split[1]
 
               # precompile if this is the first deploy
@@ -29,12 +29,12 @@ namespace :deploy do
               execute(:ls, latest_release_path.join('assets_manifest_backup')) rescue raise(PrecompileRequired)
 
               fetch(:assets_dependencies).each do |dep|
-		release = release_path.join(dep)
-		latest = latest_release_path.join(dep)
-		
-		# skip if both directories/files do not exist
-		next if [release, latest].map{|d| test "[ -e #{d} ]"}.uniq == [false]
-		
+                release = release_path.join(dep)
+                latest = latest_release_path.join(dep)
+
+                # skip if both directories/files do not exist
+                next if [release, latest].map{|d| test "[ -e #{d} ]"}.uniq == [false]
+
                 # execute raises if there is a diff
                 execute(:diff, '-Nqr', release, latest) rescue raise(PrecompileRequired)
               end

--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -15,7 +15,9 @@ namespace :deploy do
     task :precompile do
       on roles(fetch(:assets_roles)) do
         within release_path do
-          with rails_env: fetch(:rails_env) do
+          # assets_env should be a hash, ie: assets_env: { skip_it: false }
+          _assets_env = fetch(:assets_env, {}).merge(rails_env: fetch(:rails_env))
+          with _assets_env do
             begin
               # find the most recent release
               latest_release = capture(:ls, '-xr', releases_path).split[1]

--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -41,8 +41,17 @@ namespace :deploy do
 
               info("Skipping asset precompile, no asset diff found")
 
-              # copy over all of the assets from the last release
-              execute(:cp, '-r', latest_release_path.join('public', fetch(:assets_prefix)), release_path.join('public', fetch(:assets_prefix)))
+              release_asset_path = release_path.join('public', fetch(:assets_prefix))
+              # skip if assets directory is symlink
+              begin
+                execute(:test, '-L', release_asset_path.to_s)
+              rescue
+                # copy over all of the assets from the last release
+                execute(:cp, '-r', latest_release_path.join('public', fetch(:assets_prefix)), release_asset_path.parent)
+              end
+
+              # copy assets if manifest file is not exist (this is first deploy after using symlink)
+              execute(:ls, release_asset_path.join('manifest*')) rescue raise(PrecompileRequired)
             rescue PrecompileRequired
               execute(:rake, "assets:precompile")
             end


### PR DESCRIPTION
In some project, there's some code that do something that maybe cost a lot of time, but it's worthless at compile assets. We may want to skip it. So I add a `assets_env` variable to make it.

Maybe it's not necessary, but we have more than a option to meet our complex logic.
:)