### PR TITLE
Skip cleanup assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ And then:
 Add this line to `Capfile`, after `require 'capistrano/rails/assets'`
 
     require 'capistrano/faster_assets'
+    
+### Warning
+
+Please keep in mind, that if you use ERB in your assets, you might run into cases where Capistrano won't recompile assets when needed. For instance, let's say you have a CoffeeScript file like this:
+
+```coffee
+text = <%= helper.get_text %>
+```
+
+The assets might not get recompiled, even if they have to, as this gem only checks if the asset file has changed (which is probably the only safe/fast way to do this).
 
 ### More Capistrano automation?
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Add this to `Gemfile`:
 
     group :development do
       gem 'capistrano', '~> 3.1'
+      gem 'capistrano-rails', '~> 1.1'
       gem 'capistrano-faster-assets', '~> 1.0'
     end
 

--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -42,7 +42,7 @@ namespace :deploy do
               info("Skipping asset precompile, no asset diff found")
 
               # copy over all of the assets from the last release
-              execute(:cp, '-rT', latest_release_path.join('public', fetch(:assets_prefix)), release_path.join('public', fetch(:assets_prefix)))
+              execute(:cp, '-r', latest_release_path.join('public', fetch(:assets_prefix)), release_path.join('public', fetch(:assets_prefix)))
             rescue PrecompileRequired
               execute(:rake, "assets:precompile")
             end

--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -42,7 +42,7 @@ namespace :deploy do
               info("Skipping asset precompile, no asset diff found")
 
               # copy over all of the assets from the last release
-              execute(:cp, '-r', latest_release_path.join('public', fetch(:assets_prefix)), release_path.join('public', fetch(:assets_prefix)))
+              execute(:cp, '-rT', latest_release_path.join('public', fetch(:assets_prefix)), release_path.join('public', fetch(:assets_prefix)))
             rescue PrecompileRequired
               execute(:rake, "assets:precompile")
             end

--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -5,60 +5,69 @@
 set :assets_dependencies, %w(app/assets lib/assets vendor/assets Gemfile.lock config/routes.rb)
 
 # clear the previous precompile task
-Rake::Task["deploy:assets:precompile"].clear_actions
+Rake::Task["deploy:compile_assets"].clear_actions
+Rake::Task["deploy:cleanup_assets"].clear_actions
 class PrecompileRequired < StandardError;
 end
 
 namespace :deploy do
-  namespace :assets do
-    desc "Precompile assets"
-    task :precompile do
-      on roles(fetch(:assets_roles)) do
-        within release_path do
-          with rails_env: fetch(:rails_env) do
-            begin
-	      # find the most recent release
-              latest_release = capture(:ls, '-xr', releases_path).split[1]
+  desc "Compile and cleanup assets if necessary"
+  task :compile_and_cleanup_assets do
+    on roles(fetch(:assets_roles)) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          begin
+            # find the most recent release
+            latest_release = capture(:ls, '-xr', releases_path).split[1]
 
-              # precompile if this is the first deploy
-              raise PrecompileRequired unless latest_release
+            # precompile if this is the first deploy
+            raise PrecompileRequired unless latest_release
 
-              latest_release_path = releases_path.join(latest_release)
+            latest_release_path = releases_path.join(latest_release)
 
-              # precompile if the previous deploy failed to finish precompiling
-              execute(:ls, latest_release_path.join('assets_manifest_backup')) rescue raise(PrecompileRequired)
+            # precompile if the previous deploy failed to finish precompiling
+            execute(:ls, latest_release_path.join('assets_manifest_backup')) rescue raise(PrecompileRequired)
 
-              fetch(:assets_dependencies).each do |dep|
-		release = release_path.join(dep)
-		latest = latest_release_path.join(dep)
-		
-		# skip if both directories/files do not exist
-		next if [release, latest].map{|d| test "[ -e #{d} ]"}.uniq == [false]
-		
-                # execute raises if there is a diff
-                execute(:diff, '-Nqr', release, latest) rescue raise(PrecompileRequired)
-              end
+            fetch(:assets_dependencies).each do |dep|
+              release = release_path.join(dep)
+              latest = latest_release_path.join(dep)
 
-              info("Skipping asset precompile, no asset diff found")
+              # skip if both directories/files do not exist
+              next if [release, latest].map{|d| test "[ -e #{d} ]"}.uniq == [false]
 
-              # copy over all of the assets from the last release
-              release_asset_path = release_path.join('public', fetch(:assets_prefix))
-              # skip if assets directory is symlink
-              begin
-                execute(:test, '-L', release_asset_path.to_s)
-              rescue
-                execute(:cp, '-r', latest_release_path.join('public', fetch(:assets_prefix)), release_asset_path.parent)
-              end
-
-              # copy assets if manifest file is not exist (this is first deploy after using symlink)
-              execute(:ls, release_asset_path.join('manifest*')) rescue raise(PrecompileRequired)
-
-            rescue PrecompileRequired
-              execute(:rake, "assets:precompile")
+              # execute raises if there is a diff
+              execute(:diff, '-Nqr', release, latest) rescue raise(PrecompileRequired)
             end
+
+            info("Skipping asset precompile, no asset diff found")
+
+            # copy over all of the assets from the last release
+            execute(:cp, '-r', latest_release_path.join('public', fetch(:assets_prefix)), release_path.join('public', fetch(:assets_prefix)))
+
+            precompile_required = false
+
+          rescue PrecompileRequired
+            precompile_required = true
+          end
+
+          if precompile_required
+            execute(:rake, "assets:precompile")
+          end
+
+          backup_path = release_path.join('assets_manifest_backup')
+
+          execute :mkdir, '-p', backup_path
+          execute :cp,
+            detect_manifest_path,
+            backup_path
+
+          if precompile_required
+            execute :rake, "assets:clean"
           end
         end
       end
     end
   end
 end
+
+before 'deploy:compile_assets', 'deploy:compile_and_cleanup_assets'


### PR DESCRIPTION
Turn `deploy:compile_assets` and `deploy:cleanup_assets` into no-ops and replace with a single `deploy:compile_and_cleanup_assets` task that checks for asset changes and only runs the compile and cleanup if there are changes