### PR TITLE
Update path to sprockets asset manifest.

### DIFF
--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -51,7 +51,7 @@ namespace :deploy do
               end
 
               # copy assets if manifest file is not exist (this is first deploy after using symlink)
-              execute(:ls, release_asset_path.join('manifest*')) rescue raise(PrecompileRequired)
+              execute(:ls, release_asset_path.join('.sprockets-manifest*')) rescue raise(PrecompileRequired)
 
             rescue PrecompileRequired
               execute(:rake, "assets:precompile")


### PR DESCRIPTION
We noticed our assets were precompiling on every deployed.

>The task also generates a .sprockets-manifest-md5hash.json (where md5hash is an MD5 hash) that contains a list with all your assets and their respective fingerprints. This is used by the Rails helper methods to avoid handing the mapping requests back to Sprockets. 

http://guides.rubyonrails.org/asset_pipeline.html