### PR TITLE
Asset compilation flag

### DIFF
--- a/lib/capistrano/tasks/faster_assets.rake
+++ b/lib/capistrano/tasks/faster_assets.rake
@@ -3,7 +3,7 @@
 
 # set the locations that we will look for changed assets to determine whether to precompile
 set :assets_dependencies, %w(app/assets lib/assets vendor/assets Gemfile.lock config/routes.rb)
-
+set :asset_compilation_required, false
 # clear the previous precompile task
 Rake::Task["deploy:assets:precompile"].clear_actions
 class PrecompileRequired < StandardError;
@@ -65,6 +65,7 @@ namespace :deploy do
               end
 
             rescue PrecompileRequired
+              set :asset_compilation_required, true
               execute(:rake, "assets:precompile")
             end
           end


### PR DESCRIPTION
Set a flag so that tasks later in the deploy lifecycle can be aware of whether assets were compiled or not.
